### PR TITLE
Atom reuse fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "typescript-eslint": "^0.0.1-alpha.0"
   },
   "peerDependencies": {
-    "graphql-request": "^3.4.0",
-    "jotai": "^0.16.4",
-    "react": "^17.0.2"
+    "graphql-request": "*",
+    "jotai": "*",
+    "react": "*"
   }
 }

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -1,6 +1,6 @@
 import { atom, useAtom } from 'jotai';
 import { request } from 'graphql-request';
-import { useEffect, useContext, useRef } from 'react';
+import { useEffect, useContext } from 'react';
 import { AtomiContext } from './atomiContext';
 import { AtomData, AtomiAtom, ResponseData } from './types';
 
@@ -12,13 +12,11 @@ const initialAtomData: AtomData = {
   hasError: false,
 };
 
-const newAtom = atom(initialAtomData);
-
 const useQuery = (query: string): AtomDataArray => {
   const { url, cache, setCache } = useContext(AtomiContext);
   const cachedAtom = cache[query] ? cache[query].atom : null;
-  
-  const activeAtom: AtomiAtom = cachedAtom || newAtom;
+  const activeAtom: AtomiAtom = cachedAtom || atom(initialAtomData)
+
   const [atomData, setAtom] = useAtom(activeAtom);
 
   useEffect(() => {
@@ -32,11 +30,10 @@ const useQuery = (query: string): AtomDataArray => {
             hasError: false,
           }
           setCache(query, {
-            atom: newAtom,
+            atom: activeAtom,
             atomData: newAtomData,
             writeAtom: setAtom
           });
-
           setAtom(newAtomData);
         } catch {
           setAtom({
@@ -54,7 +51,7 @@ const useQuery = (query: string): AtomDataArray => {
 };
 
 export const GetAtom = (): AtomData => {
-  const [atomData] = useAtom(newAtom);
+  const [atomData] = useAtom(atom(initialAtomData));
   return atomData;
 };
 


### PR DESCRIPTION
This is an important fix.
It turns out for multiple queries we were repeatedly using the same atom instead of creating new ones, so you could only have one atom of data for your whole application.
This meant that each new query would overwrite all the data from any previous queries.
This fixes that.